### PR TITLE
Fixed typo in Finnish localisations

### DIFF
--- a/top/templates/strings/fi_strings.yaml
+++ b/top/templates/strings/fi_strings.yaml
@@ -74,7 +74,7 @@ about_section: >-
      href="https://www.mediawiki.org/wiki/API:Query">MediaWiki APIn</a> kautta saatavaa 
      tietoa kuvina ja yhteenvetoina. 
 
-     <p>Haluatko nähkä useimmin luettujen artikkeleiden luettelon Wikipedian 
+     <p>Haluatko nähdä useimmin luettujen artikkeleiden luettelon Wikipedian
      muilla kielillä? Niin mekin! <a
      href="https://github.com/hatnote/top/issues">Lähetä pyyntö</a> ja kerro, 
      jos voit auttaa meitä kääntämään mallineita.</p>


### PR DESCRIPTION
As the title says fixed typo. Corrected the word "nähkä" to "nähdä".